### PR TITLE
create gh-pages _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+theme: jekyll-theme-minimal
+include: CONTRIBUTING.md


### PR DESCRIPTION
This file provides control for generation of GitHub pages version of this document. By default, GitHub excludes "familiar" files (e.g., CONTRIBUTING.md and issue templates). This initial version should result in proper rendering of CONTRIBUTING.md and allow for more customized rendering in future.