### PR TITLE
Feature/index-to-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,7 @@ For more background on LIS, see the following articles:
 Thanks to Sujay Kumar, Christa Peters-Lidard, Jim Geiger, Eric Kemp, Kristi Arsenault, Tim Lahmers, Kimberly Slinski, Mahdi Navari for their input!
 
 Want to contribute? Check out the [Contribution Guidelines](CONTRIBUTING.md)!
+
+-----
+
+View the LIS Bootcamp as a rendered website here: <https://bmcandr.github.io/lis-bootcamp>

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,10 +6,11 @@ This repository contains a collection of information intended to rapidly orient 
 
 * [Overview of LIS](#overview-of-nasas-land-information-system)
 * [Important Links](#important-links)
-* [Glossary of Terms and Concepts](docs/LIS-glossary.md)
-* [Getting Started with LIS on NCCS Discover](docs/LIS-on-NCCS-discover.md)
+* [Glossary of Terms and Concepts](LIS-glossary.md)
+* [Getting Started with LIS on NCCS Discover](LIS-on-NCCS-discover.md)
 
-<img src='images/LIS_logo-FINAL.png' width='25%' align='right'>
+<img src='../images/LIS_logo-FINAL.png' width='25%' align='right'>
+
 ## Overview of NASA's Land Information System
 
 NASA's Land Information System (LIS) is a software framework for high performance terrestrial hydrology modeling and data assimilation developed with the goal of integrating satellite and ground-based observational data products and advanced modeling techniques to produce optimal fields of land surface states and fluxes. LIS is used to study land surface processes and land-atmosphere interactions, using "best available observations" to force and constrain the models. The LIS framework also enables a number of applications including:
@@ -24,7 +25,7 @@ The LIS framework is comprised of three components:
 * **Land Data Toolkit (LDT)** - supports the data preprocessing needs for LIS (e.g., parameter data processing, data assimilation support, forcing bias correction)
 * **Land Verification Toolkit (LVT)** - environment for model benchmarking and evaluation
 
-<img src='images/LIS-components.png' align='center'>
+<img src='../images/LIS-components.png' align='center'>
 
 <!--expand this section -->
 
@@ -59,4 +60,4 @@ For more background on LIS, see the following articles:
 
 Thanks to Sujay Kumar, Christa Peters-Lidard, Jim Geiger, Eric Kemp, Kristi Arsenault, Tim Lahmers, Kimberly Slinski, Mahdi Navari for their input!
 
-Want to contribute? Check out the [Contribution Guidelines](CONTRIBUTING.md)!
+Want to contribute? Check out the [Contribution Guidelines](../CONTRIBUTING.md)!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,62 @@
+# LIS Bootcamp
+
+This repository contains a collection of information intended to rapidly orient new members of NASA's Land Information System (LIS) team. <!--just team members or new users altogether?-->
+
+## Contents
+
+* [Overview of LIS](#overview-of-nasas-land-information-system)
+* [Important Links](#important-links)
+* [Glossary of Terms and Concepts](docs/LIS-glossary.md)
+* [Getting Started with LIS on NCCS Discover](docs/LIS-on-NCCS-discover.md)
+
+<img src='images/LIS_logo-FINAL.png' width='25%' align='right'>
+## Overview of NASA's Land Information System
+
+NASA's Land Information System (LIS) is a software framework for high performance terrestrial hydrology modeling and data assimilation developed with the goal of integrating satellite and ground-based observational data products and advanced modeling techniques to produce optimal fields of land surface states and fluxes. LIS is used to study land surface processes and land-atmosphere interactions, using "best available observations" to force and constrain the models. The LIS framework also enables a number of applications including:
+
+* weather and climate model initialization
+* water resources management
+* natural hazards management
+
+The LIS framework is comprised of three components:
+
+* **Land Information System (LIS)** - the modeling and data assimilation framework
+* **Land Data Toolkit (LDT)** - supports the data preprocessing needs for LIS (e.g., parameter data processing, data assimilation support, forcing bias correction)
+* **Land Verification Toolkit (LVT)** - environment for model benchmarking and evaluation
+
+<img src='images/LIS-components.png' align='center'>
+
+<!--expand this section -->
+
+For more background on LIS, see the following articles:
+
+<!-- add links -->
+* [Kumar et al. (2006): Land Information System: An interoperable Framework for High Resolution Land Surface Modeling, Environmental Modeling and Software, Vol 21, pp 1402-1415.](http://prhouser.com/houser_files/Kumar2006.pdf)
+
+* [Peter-Lidard et al. (2007): High-performance earth system modeling with NASA/GSFC’s Land Information System, Innovations in Systems and Software Engineering, 3(3),157-165.](http://prhouser.com/houser_files/LIS2007.pdf)
+
+-----
+
+## Important Links
+
+* [LIS Website](https://lis.gsfc.nasa.gov/)
+    * Documentation
+        * [LIS Documentation](https://lis.gsfc.nasa.gov/documentation/lis)
+            * Planning to contribute? Check out the LIS Developers' Guide before you get started.
+        * [LDT Documentation](https://lis.gsfc.nasa.gov/documentation/ldt)
+        * [LVT Documentation](https://lis.gsfc.nasa.gov/documentation/lvt)
+    * [Frequently Asked Questions](https://lis.gsfc.nasa.gov/faq-page)
+* [LIS GitHub Page](https://github.com/NASA-LIS)
+    * This is where the LIS source code lives!
+* [NASA's Modeling Guru Forum](https://modelingguru.nasa.gov/community/atmospheric/lis)
+    * Need help with LIS? Search the forum and ask for help!
+
+-----
+
+### Acknowledgements
+
+<!--Did you contribute? Don't forget to add your name below!-->
+
+Thanks to Sujay Kumar, Christa Peters-Lidard, Jim Geiger, Eric Kemp, Kristi Arsenault, Tim Lahmers, Kimberly Slinski, Mahdi Navari for their input!
+
+Want to contribute? Check out the [Contribution Guidelines](CONTRIBUTING.md)!


### PR DESCRIPTION
Create an `index.md` file in the `docs/` directory. The source branch for GitHub Pages should be set to point to `docs/` after this PR is merged. The Bootcamp will then be rendered from this directory and free up the README.md to provide information about the repo rather than hosting its homepage.